### PR TITLE
Removed superfluous files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ config.guess
 config.status
 config.sub
 config.h.in
+config.h.in~
 configure
+compile
 depcomp
 install-sh
 missing

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,3 @@
 EXTRA_DIST = NOTES TODO fsv.spec fsv.spec.in fsv.wmconfig
 SUBDIRS = debug doc intl lib po src
+AUTOMAKE_OPTIONS = foreign


### PR DESCRIPTION
The following pull request adds two more files generated by automake to [`.gitignore`](https://github.com/mcuelenaere/fsv/commit/64852b6e7b9db8ab568d8b25a61c1f39529df886). 

Since we're not following the strict GNU packaging guidelines, appending the `foreign` option to [`automake`](https://github.com/mcuelenaere/fsv/commit/9cee15c1631392fc3063956620efc26768b89249) makes sure we don't build an unnecessary, empty `README`.