### PR TITLE
Updated with correct packages for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Useful info and screenshots of the original SGI IRIX implementation are availabl
 
 1. Clone the repository
 2. Make a configure script: `./autogen.sh`
-3. Install dependencies (Ubuntu): `sudo apt-get install libgtk2.0-dev libgl1-mesa-dev libglu1-mesa-dev`
+3. Install dependencies (Ubuntu): `sudo apt-get install libgtkgl2.0-dev libgl1-mesa-dev libglu1-mesa-dev`
 4. Do the install dance:
 
     - ./configure


### PR DESCRIPTION
The first dependency to install is apparently "libgtkgl2.0-dev", not "libgtk2.0-dev". I encountered this issue when I attempted to clone and install this myself, ran "./configure", and it replied that it couldn't find "gtkgl-2.0". Had to search Ubuntu Packages to figure out the error.